### PR TITLE
AIP 180: Surface more values for /search/trending

### DIFF
--- a/reference-yml/coingecko-pro-api-v3.yml
+++ b/reference-yml/coingecko-pro-api-v3.yml
@@ -2165,6 +2165,21 @@ paths:
         This endpoint allows you **query trending search coins, NFTs and
         categories on CoinGecko in the last 24 hours**
       operationId: trending-search
+      parameters:
+        - name: show_max
+          in: query
+          description: >-
+            show max number of results available for the given type
+            <br> Available values: `coins`, `nfts`, `categories`
+            <br> Example: `coins` or `coins,nfts,categories`
+          required: false
+          schema:
+            type: string
+          examples:
+            one value:
+              value: coins
+            multiple values:
+              value: coins,nfts,categories
       responses:
         '200':
           description: List trending coins by most popular first

--- a/reference/coingecko-pro-api-v3.json
+++ b/reference/coingecko-pro-api-v3.json
@@ -2851,6 +2851,25 @@
         "summary": "Trending Search List",
         "description": "This endpoint allows you **query trending search coins, NFTs and categories on CoinGecko in the last 24 hours**",
         "operationId": "trending-search",
+        "parameters": [
+          {
+            "name": "show_max",
+            "in": "query",
+            "description": "show max number of results available for the given type <br> Available values: `coins`, `nfts`, `categories` <br> Example: `coins` or `coins,nfts,categories`",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "one value": {
+                "value": "coins"
+              },
+              "multiple values": {
+                "value": "coins,nfts,categories"
+              }
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "List trending coins by most popular first",


### PR DESCRIPTION
This pull request includes changes to the CoinGecko Pro API v3 documentation, specifically adding a new query parameter to the trending search endpoint. The changes are reflected in both the YAML and JSON reference files.

New query parameter added:

* [`reference-yml/coingecko-pro-api-v3.yml`](diffhunk://#diff-347c8b63caba97fd35703ff9d29e5146bee4fe6640364349df9efd60df552d88R2168-R2182): Added the `show_max` query parameter to allow users to specify the maximum number of results for coins, NFTs, and categories.
* [`reference/coingecko-pro-api-v3.json`](diffhunk://#diff-a2fb7ea2ec7f7913acf18f60069b8bfbbc5c4914793089d3ddc49ea85cdfa347R2854-R2872): Added the `show_max` query parameter with examples for single and multiple values.