### PR TITLE
AIP 225: Allow lookup coins with symbol or names in /coins/markets

### DIFF
--- a/reference-yml/coingecko-pro-api-v3.yml
+++ b/reference-yml/coingecko-pro-api-v3.yml
@@ -389,6 +389,41 @@ paths:
               value: bitcoin
             multiple values:
               value: bitcoin,ethereum
+        - name: names
+          in: query
+          description: >-
+            coins' names, comma-separated if querying more than 1 coin.
+          required: false
+          schema:
+            type: string
+          examples:
+            one value:
+              value: Bitcoin
+            multiple values:
+              value: Bitcoin,Ethereum
+        - name: symbols
+          in: query
+          description: >-
+            coins' symbols, comma-separated if querying more than 1 coin.
+          required: false
+          schema:
+            type: string
+          examples:
+            one value:
+              value: btc
+            multiple values:
+              value: btc,eth
+        - name: include_tokens
+          in: query
+          description: >-
+            for `symbols` lookups, specify `all` to include all matching tokens
+            <br> Default `top` returns top-ranked tokens (by market cap or volume)
+          required: false
+          schema:
+            type: string
+            enum:
+              - top
+              - all
         - name: category
           in: query
           description: >-

--- a/reference/coingecko-pro-api-v3.json
+++ b/reference/coingecko-pro-api-v3.json
@@ -516,6 +516,53 @@
             }
           },
           {
+            "name": "names",
+            "in": "query",
+            "description": "coins' names, comma-separated if querying more than 1 coin.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "one value": {
+                "value": "Bitcoin"
+              },
+              "multiple values": {
+                "value": "Bitcoin,Ethereum"
+              }
+            }
+          },
+          {
+            "name": "symbols",
+            "in": "query",
+            "description": "coins' symbols, comma-separated if querying more than 1 coin.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "one value": {
+                "value": "btc"
+              },
+              "multiple values": {
+                "value": "btc,eth"
+              }
+            }
+          },
+          {
+            "name": "include_tokens",
+            "in": "query",
+            "description": "for `symbols` lookups, specify `all` to include all matching tokens <br> Default `top` returns top-ranked tokens (by market cap or volume)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "top",
+                "all"
+              ]
+            }
+          },
+          {
             "name": "category",
             "in": "query",
             "description": "filter based on coins' category <br> *refers to [`/coins/categories/list`](/reference/coins-categories-list).",


### PR DESCRIPTION
This pull request adds new query parameters to the CoinGecko Pro API V3 reference files to enhance the querying capabilities. The most important changes include the addition of `names`, `symbols`, and `include_tokens` parameters.

Enhancements to querying capabilities:

* [`reference-yml/coingecko-pro-api-v3.yml`](diffhunk://#diff-347c8b63caba97fd35703ff9d29e5146bee4fe6640364349df9efd60df552d88R392-R426): Added `names` query parameter to allow querying by coin names, with examples for single and multiple values.
* [`reference-yml/coingecko-pro-api-v3.yml`](diffhunk://#diff-347c8b63caba97fd35703ff9d29e5146bee4fe6640364349df9efd60df552d88R392-R426): Added `symbols` query parameter to allow querying by coin symbols, with examples for single and multiple values.
* [`reference-yml/coingecko-pro-api-v3.yml`](diffhunk://#diff-347c8b63caba97fd35703ff9d29e5146bee4fe6640364349df9efd60df552d88R392-R426): Added `include_tokens` query parameter to specify whether to include all matching tokens or only the top-ranked tokens.
* [`reference/coingecko-pro-api-v3.json`](diffhunk://#diff-a2fb7ea2ec7f7913acf18f60069b8bfbbc5c4914793089d3ddc49ea85cdfa347R518-R564): Added `names` query parameter to the JSON reference file, mirroring the YAML changes.
* [`reference/coingecko-pro-api-v3.json`](diffhunk://#diff-a2fb7ea2ec7f7913acf18f60069b8bfbbc5c4914793089d3ddc49ea85cdfa347R518-R564): Added `symbols` and `include_tokens` query parameters to the JSON reference file, mirroring the YAML changes.

cc @sachiew 