### PR TITLE
[Public/Demo] AIP 225: Allow lookup coins with symbol or names in /coins/markets

### DIFF
--- a/reference-yml/coingecko-public-api-v3.yml
+++ b/reference-yml/coingecko-public-api-v3.yml
@@ -288,6 +288,41 @@ paths:
               value: bitcoin
             multiple values:
               value: bitcoin,ethereum
+        - name: names
+          in: query
+          description: >-
+            coins' names, comma-separated if querying more than 1 coin.
+          required: false
+          schema:
+            type: string
+          examples:
+            one value:
+              value: Bitcoin
+            multiple values:
+              value: Bitcoin,Ethereum
+        - name: symbols
+          in: query
+          description: >-
+            coins' symbols, comma-separated if querying more than 1 coin.
+          required: false
+          schema:
+            type: string
+          examples:
+            one value:
+              value: btc
+            multiple values:
+              value: btc,eth
+        - name: include_tokens
+          in: query
+          description: >-
+            for `symbols` lookups, specify `all` to include all matching tokens
+            <br> Default `top` returns top-ranked tokens (by market cap or volume)
+          required: false
+          schema:
+            type: string
+            enum:
+              - top
+              - all
         - name: category
           in: query
           description: >-

--- a/reference/coingecko-public-api-v3.json
+++ b/reference/coingecko-public-api-v3.json
@@ -389,6 +389,53 @@
             }
           },
           {
+            "name": "names",
+            "in": "query",
+            "description": "coins' names, comma-separated if querying more than 1 coin.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "one value": {
+                "value": "Bitcoin"
+              },
+              "multiple values": {
+                "value": "Bitcoin,Ethereum"
+              }
+            }
+          },
+          {
+            "name": "symbols",
+            "in": "query",
+            "description": "coins' symbols, comma-separated if querying more than 1 coin.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "one value": {
+                "value": "btc"
+              },
+              "multiple values": {
+                "value": "btc,eth"
+              }
+            }
+          },
+          {
+            "name": "include_tokens",
+            "in": "query",
+            "description": "for `symbols` lookups, specify `all` to include all matching tokens <br> Default `top` returns top-ranked tokens (by market cap or volume)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "top",
+                "all"
+              ]
+            }
+          },
+          {
             "name": "category",
             "in": "query",
             "description": "filter based on coins' category <br> *refers to [`/coins/categories/list`](/reference/coins-categories-list).",


### PR DESCRIPTION
This pull request includes updates to the CoinGecko API documentation files to add new query parameters. These changes enhance the API's functionality by allowing more flexible queries for coin names, symbols, and token inclusion.

Enhancements to query parameters:

* Added the `names` query parameter to allow querying by coin names, comma-separated for multiple coins. (`reference-yml/coingecko-public-api-v3.yml`, `reference/coingecko-public-api-v3.json`) [[1]](diffhunk://#diff-78143c31875eea848edb62bd00c3f66c814f01a95d78cd22e3956190f760e0cbR291-R325) [[2]](diffhunk://#diff-1384eaf4472bd0e3f00f10715810cc2a9653671fc70978e5d53d8e1adea88002R391-R437)
* Added the `symbols` query parameter to allow querying by coin symbols, comma-separated for multiple coins. (`reference-yml/coingecko-public-api-v3.yml`, `reference/coingecko-public-api-v3.json`) [[1]](diffhunk://#diff-78143c31875eea848edb62bd00c3f66c814f01a95d78cd22e3956190f760e0cbR291-R325) [[2]](diffhunk://#diff-1384eaf4472bd0e3f00f10715810cc2a9653671fc70978e5d53d8e1adea88002R391-R437)
* Added the `include_tokens` query parameter to specify whether to include all matching tokens or just the top-ranked tokens for symbol lookups. (`reference-yml/coingecko-public-api-v3.yml`, `reference/coingecko-public-api-v3.json`) [[1]](diffhunk://#diff-78143c31875eea848edb62bd00c3f66c814f01a95d78cd22e3956190f760e0cbR291-R325) [[2]](diffhunk://#diff-1384eaf4472bd0e3f00f10715810cc2a9653671fc70978e5d53d8e1adea88002R391-R437)

cc @sachiew 